### PR TITLE
replace link with angle brackets or remove the schema

### DIFF
--- a/announcements/announcements.go
+++ b/announcements/announcements.go
@@ -112,7 +112,7 @@ func remove(im *imap.Dialer, uids []int) error {
 	return err
 }
 
-var bracketLinkRe = regexp.MustCompile(`\[((https?://)([^\]]*[^\\\]]))\]\((https?://[^)]+[^\\)])\)`)
+var bracketLinkRe = regexp.MustCompile(`\[((https?://)([^\]]*[^\\\]]))\]\((https?://[^)]*[^\\)])\)`)
 
 var converter = md.NewConverter("", true, &md.Options{
 	HeadingStyle:    "setext",


### PR DESCRIPTION
Discord will not convert links whose display text is a link.  
So we need use angle bracket form `<https://xxx>` or bracket form without the `https://` prefix in brackets.

Example: https://go.dev/play/p/tPz_YcnEU80