### PR TITLE
make message split only happens at new line

### DIFF
--- a/announcements/announcements.go
+++ b/announcements/announcements.go
@@ -156,7 +156,7 @@ func buildContents(maxLen int, subject, body string) (contents []string) {
 	for max < len(body) {
 		body = strings.TrimSpace(body)
 
-		i := strings.LastIndexAny(body[:max], "\n.!")
+		i := strings.LastIndex(body[:max], "\n")
 		// there are no new lines in the first max len chars
 		if i == -1 {
 			i = max - 1


### PR DESCRIPTION
If the split happens at `.`, URLs such as `https://go.dev/dl/#go1.26rc2` may be split into two chunks `https://go.dev/dl/#go1.` and `26rc2`